### PR TITLE
Fix - now mutpos are generated from rdata even if you happen to have …

### DIFF
--- a/Scripts/utility/graphics/t47_graphics/tool/generate_mutpos_from_rdat.m
+++ b/Scripts/utility/graphics/t47_graphics/tool/generate_mutpos_from_rdat.m
@@ -12,7 +12,8 @@ if nargin == 0; help( mfilename ); return; end;
 
 mutpos = ones(1, size(cell_array, 2)) * NaN; 
 for i = 2:size(mutpos, 2)
-  mutpos_inferred = str2num(strrep(strrep(strrep(strrep(strrep(cell_array{i}{1}, 'mutation:', ''), 'G', ''), 'A', ''), 'C', ''), 'U', ''));
+  %mutpos_inferred = str2num(strrep(strrep(strrep(strrep(strrep(strrep(cell_array{i}{1}, 'mutation:', ''), 'G', ''), 'A', ''), 'C', ''), 'U', ''),'X',''));
+  mutpos_inferred = str2num(regexprep(cell_array{i}{1},'\D',''));
   if ~isempty( mutpos_inferred )
     mutpos(i) = mutpos_inferred;
   end


### PR DESCRIPTION
…`mutation:X1X` etc. & it seems to be faster anyway

Before:

	>> output_Zscore_from_rdat('out.txt', 'RNAPZ14_1M7_0000.rdat')
	Parsing file from rdat: RNAPZ14_1M7_0000.rdat
	Number of reactivity lines: 59
	mutpos (1 x 59) is generated from d_rdat.data_annotations.
	Subscript indices must either be real positive integers or logicals.

	Error in output_Zscore_from_rdat>get_Zscore_and_apply_filter (line 219)
	Zscore_full( pos1, pos2(gp) ) = Zscore(:,gp) * ZSCORE_SCALING;

	Error in output_Zscore_from_rdat (line 67)
	  [ Z, mutpos ] = get_Zscore_and_apply_filter( d, d_nomod, MEAN_EXPOSURE_CUTOFF,
	  ZSCORE_OFFSET, APPLY_ZSCORE_OFFSET, ONLY_A_C, ignore_mut );

now you will get the plot!

Signed-off-by: Marcin Magnus <magnus@genesilico.pl> & Filip Ciepiela